### PR TITLE
lint-staged の設定を変更

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,11 +20,10 @@
   },
   "husky": {
     "hooks": {
-      "pre-commit": "lint-staged"
+      "pre-commit": "yarn lint && lint-staged"
     }
   },
   "lint-staged": {
-    "*.{ts}": "yarn lint",
     "*.{scss}": "yarn stylelint",
     "*.{ts,html,scss}": "yarn prettier:check"
   },

--- a/package.json
+++ b/package.json
@@ -20,10 +20,13 @@
   },
   "husky": {
     "hooks": {
-      "pre-commit": "yarn lint && lint-staged"
+      "pre-commit": "lint-staged"
     }
   },
   "lint-staged": {
+    "projects/canaria/**/*.{ts}": "yarn run tslint -c projects/canaria/tslint.json",
+    "projects/fullerene/**/*.{ts}": "yarn run tslint -c projects/fullerene/tslint.json",
+    "projects/utilities/**/*.{ts}": "yarn run tslint -c projects/utilities/tslint.json",
     "*.{scss}": "yarn stylelint",
     "*.{ts,html,scss}": "yarn prettier:check"
   },


### PR DESCRIPTION
#50 

ng lint がファイル指定をして実行するのが難しいため Git staged のファイルを project ごとに判定して該当の tslint.json を読み込んで tslint を実行するように変更